### PR TITLE
Catch monomers vs chains fix

### DIFF
--- a/fragalysis_api/xcimporter/conversion_pdb_mol.py
+++ b/fragalysis_api/xcimporter/conversion_pdb_mol.py
@@ -283,7 +283,7 @@ class Ligand:
 
         meta_data_dict = {'Blank':'',
                           'fragalysis_name': file_base,
-                          'crystal_name': file_base.split("_")[0],
+                          'crystal_name': file_base.rsplit('_', 1)[0],
                           'smiles': smiles,
                           'new_smiles':'',
                           'alternate_name':'',

--- a/fragalysis_api/xcimporter/xcimporter.py
+++ b/fragalysis_api/xcimporter/xcimporter.py
@@ -93,9 +93,10 @@ def xcimporter(in_dir, out_dir, target, metadata=False, validate=False, monomeri
     for aligned, smiles in list(zip(aligned_dict['bound_pdb'], aligned_dict['smiles'])):
         try:
             if smiles:
-                new = set_up(target_name=target, infile=os.path.abspath(aligned), out_dir=out_dir, smiles_file=os.path.abspath(smiles))
+                new = set_up(target_name=target, infile=os.path.abspath(aligned),
+                             out_dir=out_dir, monomerize=monomerize, smiles_file=os.path.abspath(smiles))
             else:
-                new = set_up(target_name=target, infile=os.path.abspath(aligned), out_dir=out_dir)
+                new = set_up(target_name=target, infile=os.path.abspath(aligned), out_dir=out_dir, monomerize=monomerize)
         except AssertionError:
             print(aligned, "is not suitable, please consider removal or editing")
             for file in os.listdir(os.path.join(out_dir, "tmp")):

--- a/tests/xcimporter/test_conversion.py
+++ b/tests/xcimporter/test_conversion.py
@@ -17,8 +17,10 @@ class PDBexample1(ConversionTest):
     @classmethod
     def setUpClass(cls):
         super(PDBexample1, cls).setUpClass()
-        cls.obj_5q1j = set_up(target_name="5q1j", infile=os.path.join(cls.dir_input,'5q1j.pdb'), out_dir=cls.dir_output)
-        cls.obj_5qj7 = set_up(target_name="5qj7", infile=os.path.join(cls.dir_input,'5qj7.pdb'), out_dir=cls.dir_output)
+        cls.obj_5q1j = set_up(target_name="5q1j", infile=os.path.join(cls.dir_input,'5q1j.pdb'), monomerize = False,
+                              out_dir=cls.dir_output)
+        cls.obj_5qj7 = set_up(target_name="5qj7", infile=os.path.join(cls.dir_input,'5qj7.pdb'), monomerize = False,
+                              out_dir=cls.dir_output)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Hi Rachael - this version catches if a ligand has been monomerised or not. Saves ligand file names to 'xxx_0A' for monomerised and 'xxx_0' for non-monomerised.  