### PR TITLE
Convertin pdb manip to gemmi + solving seperate ligand chains

### DIFF
--- a/fragalysis_api/xcimporter/align.py
+++ b/fragalysis_api/xcimporter/align.py
@@ -481,14 +481,13 @@ class Monomerize:
 
                 chain_dists[chain_name] = ligchain_pos.dist(chain_temp.calculate_center_of_mass())
 
-        closest_chain = min(chain_dists, key=chain_dists.get)
-
-        ligchain.name = closest_chain
-        base_structure.merge_chain_parts()
-
-        # Remove remaining chain parts
-        for x in [j.name for j in base_models if not j.name == closest_chain]:
-            base_models.remove_chain(x)
+        if len(chain_dists) > 0: # I don't think this is sufficient...
+            # Remove remaining chain parts
+            closest_chain = min(chain_dists, key=chain_dists.get)
+            ligchain.name = closest_chain
+            base_structure.merge_chain_parts()
+            for x in [j.name for j in base_models if not j.name == closest_chain]:
+                base_models.remove_chain(x)
 
         # Rename Chain to corresponding chain then save!
         name = os.path.splitext(os.path.basename(f))[0] + '_' + str(lig_chain)

--- a/fragalysis_api/xcimporter/align.py
+++ b/fragalysis_api/xcimporter/align.py
@@ -458,12 +458,42 @@ class Monomerize:
         return wanted_ligs
 
     def save_chain(self, lig, f):
+        # Figure out what lig and f are...
         lig_chain = lig[5]
-        name = os.path.splitext(os.path.basename(f))[0] + '_' + str(lig_chain)
+
+        base_structure = gemmi.read_structure(f)
+        base_models = base_structure[0]
+
+        ligchain = base_models.find_chain(lig_chain)
+        ligchain_pos = ligchain[0][0].pos
+
+        chain_dists = {}
+        for chain in base_models:
+            chain_name = chain.name
+            # Probably the wrong way to go about this... need to explore gemmi more
+            if chain.has_subchains_assigned():
+
+                chain_temp = gemmi.read_structure(f)[0]
+
+                for k in [j.name for j in chain_temp]:
+                    if not k == chain_name:
+                        chain_temp.remove_chain(k)
+
+                chain_dists[chain_name] = ligchain_pos.dist(chain_temp.calculate_center_of_mass())
+
+        closest_chain = min(chain_dists, key=chain_dists.get)
+
+        ligchain.name = closest_chain
+        base_structure.merge_chain_parts()
+
+        # Remove remaining chain parts
+        for x in [j.name for j in base_models if not j.name == closest_chain]:
+            base_models.remove_chain(x)
+
+        # Rename Chain to corresponding chain then save!
+        name = os.path.splitext(os.path.basename(f))[0] + '_' + str(ligchain.name)
         filename = os.path.join(self.outdir, f'{name}_mono.pdb')
-        pymol.cmd.load(f, name)
-        pymol.cmd.save(filename, f'chain {lig_chain}')
-        pymol.cmd.reinitialize()
+        base_structure.write_pdb(filename)
 
         return filename
 

--- a/fragalysis_api/xcimporter/align.py
+++ b/fragalysis_api/xcimporter/align.py
@@ -491,7 +491,7 @@ class Monomerize:
             base_models.remove_chain(x)
 
         # Rename Chain to corresponding chain then save!
-        name = os.path.splitext(os.path.basename(f))[0] + '_' + str(ligchain.name)
+        name = os.path.splitext(os.path.basename(f))[0] + '_' + str(lig_chain)
         filename = os.path.join(self.outdir, f'{name}_mono.pdb')
         base_structure.write_pdb(filename)
 


### PR DESCRIPTION
Closes #49 

This branch should fix the monomer mode to automatically:

Merging into the map-alignment branch as this is the one that contains gemmi stuff

1) Find the corresponding chain where the ligand presides
2) Find the nearest chain, containing AA,
3) Change the name of the ligand chain to the nearest chain
4) Collapse/Remove all other chains from the pdb. The mono file will be called be designated as whatever the ligand chain id is (despite the protein chain being named otherwise...)

Currently testing, do not merge until I have tested throughly :joy: